### PR TITLE
기존 서비스의 반환값을 dto 로 변경

### DIFF
--- a/growing-shop-java/src/main/java/com/example/growingshop/domain/auth/api/AuthController.java
+++ b/growing-shop-java/src/main/java/com/example/growingshop/domain/auth/api/AuthController.java
@@ -21,7 +21,7 @@ public class AuthController {
     private final UserService userService;
 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse.TokenRes> login(@RequestBody @Validated AuthRequest.LoginReq login) throws IllegalAccessException {
+    public ResponseEntity<AuthResponse.TokenRes> login(@RequestBody @Validated AuthRequest.LoginReq login) {
         return new ResponseEntity<>(jwtTokenProvider.generateToken(login), HttpStatus.OK);
     }
 

--- a/growing-shop-java/src/main/java/com/example/growingshop/domain/auth/dto/AuthRequest.java
+++ b/growing-shop-java/src/main/java/com/example/growingshop/domain/auth/dto/AuthRequest.java
@@ -14,6 +14,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthRequest {
 
     @Getter

--- a/growing-shop-java/src/main/java/com/example/growingshop/domain/auth/dto/AuthResponse.java
+++ b/growing-shop-java/src/main/java/com/example/growingshop/domain/auth/dto/AuthResponse.java
@@ -4,9 +4,10 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthResponse {
 
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor
     @Builder
     @Getter

--- a/growing-shop-java/src/main/java/com/example/growingshop/domain/company/dto/CompanyResponse.java
+++ b/growing-shop-java/src/main/java/com/example/growingshop/domain/company/dto/CompanyResponse.java
@@ -1,0 +1,31 @@
+package com.example.growingshop.domain.company.dto;
+
+import com.example.growingshop.domain.company.domain.Company;
+import com.example.growingshop.domain.company.domain.CompanyGrade;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CompanyResponse {
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    public static class CompanyRes {
+        private Long id;
+        private String name;
+        private String businessRegistrationNumber;
+        private CompanyGrade grade;
+
+        public static CompanyRes from(Company company) {
+            CompanyRes res = new CompanyRes();
+
+            res.id = company.getId();
+            res.name = company.getName();
+            res.businessRegistrationNumber = company.getBusinessRegistrationNumber();
+            res.grade = company.getGrade();
+
+            return res;
+        }
+    }
+}

--- a/growing-shop-java/src/main/java/com/example/growingshop/domain/company/service/CompanyService.java
+++ b/growing-shop-java/src/main/java/com/example/growingshop/domain/company/service/CompanyService.java
@@ -1,6 +1,7 @@
 package com.example.growingshop.domain.company.service;
 
 import com.example.growingshop.domain.company.domain.Company;
+import com.example.growingshop.domain.company.dto.CompanyResponse;
 import com.example.growingshop.domain.company.repository.CompanyRepo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,8 +13,10 @@ import javax.persistence.EntityNotFoundException;
 public class CompanyService {
     private final CompanyRepo companyRepo;
 
-    public Company getCompany(Long id) {
-        return companyRepo.findById(id)
+    public CompanyResponse.CompanyRes getCompany(Long id) {
+        Company company = companyRepo.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(id + " 에 해당하는 업체가 존재하지 않습니다."));
+
+        return CompanyResponse.CompanyRes.from(company);
     }
 }

--- a/growing-shop-java/src/main/java/com/example/growingshop/domain/user/dto/UserResponse.java
+++ b/growing-shop-java/src/main/java/com/example/growingshop/domain/user/dto/UserResponse.java
@@ -1,0 +1,45 @@
+package com.example.growingshop.domain.user.dto;
+
+import com.example.growingshop.domain.company.dto.CompanyResponse;
+import com.example.growingshop.domain.user.domain.User;
+import com.example.growingshop.domain.user.domain.UserGrade;
+import com.example.growingshop.domain.user.domain.UserType;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserResponse {
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    public static class UserRes {
+        private Long id;
+        private String name;
+        private String mobile;
+        private String email;
+        private String loginId;
+        private CompanyResponse.CompanyRes company;
+        private UserType type;
+        private UserGrade grade;
+
+        public static UserRes from(User user) {
+            UserRes res = new UserRes();
+
+            res.id = user.getId();
+            res.name = user.getName();
+            res.mobile = user.getMobile();
+            res.email = user.getEmail();
+            res.loginId = user.getLoginId();
+
+            if (user.getCompany() != null) {
+                res.company = CompanyResponse.CompanyRes.from(user.getCompany());
+            }
+
+            res.type = user.getType();
+            res.grade = user.getGrade();
+
+            return res;
+        }
+    }
+}

--- a/growing-shop-java/src/main/java/com/example/growingshop/domain/user/service/UserService.java
+++ b/growing-shop-java/src/main/java/com/example/growingshop/domain/user/service/UserService.java
@@ -2,8 +2,10 @@ package com.example.growingshop.domain.user.service;
 
 import com.example.growingshop.domain.auth.dto.AuthRequest;
 import com.example.growingshop.domain.company.domain.Company;
+import com.example.growingshop.domain.company.repository.CompanyRepo;
 import com.example.growingshop.domain.company.service.CompanyService;
 import com.example.growingshop.domain.user.domain.User;
+import com.example.growingshop.domain.user.dto.UserResponse;
 import com.example.growingshop.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -15,22 +17,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final CompanyService companyService;
+    private final CompanyRepo companyRepo;
 
     @Transactional
-    public User joinUser(AuthRequest.JoinReq join) {
+    public UserResponse.UserRes joinUser(AuthRequest.JoinReq join) {
         if (userRepository.findUsersByLoginId(join.getLoginId()).isPresent()) {
-            throw new IllegalArgumentException("이미 가입된 회원입니다.");
+            throw new IllegalArgumentException("이미 가입된 아이디입니다.");
         }
 
         Company company = null;
 
         if (join.getCompany() != null) {
-            company = companyService.getCompany(join.getCompany());
+            company = companyRepo.findById(join.getCompany())
+                    .orElseThrow(() -> new IllegalArgumentException(join.getCompany() + " 에 해당하는 업체가 존재하지 않습니다."));
         }
 
-        return userRepository.save(
-                join.toEntity(passwordEncoder.encode(join.getJoinPassword()), company)
+        return UserResponse.UserRes.from(
+                userRepository.save(
+                        join.toEntity(passwordEncoder.encode(join.getJoinPassword()), company)
+                )
         );
     }
 }


### PR DESCRIPTION
기존의 read/write 전용 서비스로 분리하는 작업을 진행하려다가,
관련된 내용도 없고 좋은 구조는 아닌 것 같으며,
[링크](https://github.com/next-step/jwp-refactoring/pull/549#discussion_r912384318) 내용을 바탕으로 domain-service 까지 엔티티로 통신하고, service-presentation 은 dto 로 통신하는 형태로 전체적으로 구성하기로 결정하였습니다.

캐싱 설정은 해당 브랜치가 파생된 부분과 다른 곳에 위치하여, 별도로 작업하기 위해 #18 일감에 내용을 추가하였습니다.
